### PR TITLE
Add complex rule template note for macOS/karabiner

### DIFF
--- a/Documents/firmware-software-config.md
+++ b/Documents/firmware-software-config.md
@@ -99,4 +99,4 @@ Taran from Linus Tech Tips has a great [video](https://youtu.be/GZEoss4XIgc?t=34
 ### macOS
 * Install [Brew](https://brew.sh/).
 * Open Terminal and install [Karabiner-Elements](https://karabiner-elements.pqrs.org/) with ```brew cask install karabiner-elements```.
-  * Use "Simple modifications" to bind basic/media keys. For application-specific layout use "Complex modifications".
+  * Use "Simple modifications" to bind basic/media keys. For application-specific layout use "Complex modifications" (you can import the template to get you started by searching `Hub16 apps` rule from the menu). 


### PR DESCRIPTION
I added first complex rule for the macropad to the `KE` https://github.com/pqrs-org/KE-complex_modifications/pull/653 so now you can easily add it right in the app. I'll experiment with the "simple rules" config and maybe will do just one file for both cases.